### PR TITLE
Fix libxml2 change on error ptr

### DIFF
--- a/src/libsrcml/sax2_srcsax_handler.cpp
+++ b/src/libsrcml/sax2_srcsax_handler.cpp
@@ -97,7 +97,7 @@ static int reparse_root(void* ctx) {
     memset(&roottagsax, 0, sizeof(roottagsax));
     roottagsax.initialized    = XML_SAX2_MAGIC;
     xmlSetStructuredErrorFunc(ctx, [](void * userData,
-                     xmlErrorPtr /* error */) {
+                    const xmlError* /* error */) {
 
         auto ctxt = (xmlParserCtxtPtr) userData;
         if (ctxt == nullptr)

--- a/src/libsrcml/srcSAXController.cpp
+++ b/src/libsrcml/srcSAXController.cpp
@@ -69,7 +69,7 @@ void srcSAXController::parse(srcSAXHandler * handler) {
 
     if (status != 0) {
 
-        xmlErrorPtr ep = xmlCtxtGetLastError(context->libxml2_context);
+        const xmlError* ep = xmlCtxtGetLastError(context->libxml2_context);
         SAXError error = { std::string(ep->message), ep->code };
 
         throw error;

--- a/src/libsrcml/srcsax_controller.cpp
+++ b/src/libsrcml/srcsax_controller.cpp
@@ -116,7 +116,7 @@ int srcsax_parse(srcsax_context* context) {
 
     if (status != 0 && context->srcsax_error) {
 
-        xmlErrorPtr ep = xmlCtxtGetLastError(context->libxml2_context);
+        const xmlError* ep = xmlCtxtGetLastError(context->libxml2_context);
 
         auto str_length = std::string_view(ep->message).size();
         ep->message[str_length - 1] = '\0';


### PR DESCRIPTION
Just for your information:
I had to made those modifications in order to build litgen on archlinux.

It fix some build issue with libxml2, where some pointer to xmlError are now const.